### PR TITLE
Add warp.torch to __init__

### DIFF
--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -11,3 +11,4 @@ from warp.context import *
 from warp.builtins import *
 from warp.tape import *
 from warp.utils import *
+from warp.torch import *


### PR DESCRIPTION
Allows to run

`import warp as wp`
`wp.torch.xx`

instead of

`import warp as wp`
`import warp.torch`
`wp.torch.xx`
